### PR TITLE
Fix action getters for Sketch 44

### DIFF
--- a/Make Long Shadow.sketchplugin/Contents/Sketch/script.js
+++ b/Make Long Shadow.sketchplugin/Contents/Sketch/script.js
@@ -58,9 +58,9 @@ var onRun = function(context) {
 			direction = [directionDropdown titleOfSelectedItem],
 			xMultiplier = (direction == "Bottom Left" || direction == "Top Left") ? -1 : 1,
 			yMultiplier = (direction == "Top Left" || direction == "Top Right") ? -1 : 1,
-			unionAction = [[doc actionsController] actionWithID: "MSUnionAction"],
-			flattenAction = [[doc actionsController] actionWithID: "MSFlattenAction"],
-			groupAction = [[doc actionsController] actionWithID: "MSGroupAction"],
+			unionAction = [[doc actionsController] actionForID: "MSUnionAction"],
+			flattenAction = [[doc actionsController] actionForID: "MSFlattenAction"],
+			groupAction = [[doc actionsController] actionForID: "MSGroupAction"],
 			shadowColor = hexToMSColor("#000000", 0.3),
 			layer, originalLayer, firstLayerIndex, isTextLayer;
 


### PR DESCRIPTION
Hi,
I was trying to use the plugin with Sketch 44.1 and it was not working. So debugging I found that actionWithID is not working anymore and it should be actionForID instead. I tested and it was working after this change.